### PR TITLE
Making sure we get the latest code from Kitura-Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@
 branches:
   only:
     - master
-    - travis_setup
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+# Travis CI build file for Kitura sample app.
+# Kitura runs on OS X and Linux (Ubuntu).
+# See the following URLs for further details on Travis CI
+# https://docs.travis-ci.com/user/customizing-the-build/
+# https://docs.travis-ci.com/user/docker/
+# https://docs.travis-ci.com/user/multi-os/
+
+# whitelist (branches that should be built)
+branches:
+  only:
+    - master
+    - travis_setup
+
+notifications:
+  slack:
+    secure: "VFUQIBCL8Kiubw7ojN3oJOs2TgobYaAZTCQePDATOMSRKRo/rDgsloGDc3kqGkLb0lAwky1lwKQjnRUsG1mEES6+W2K3QWsmzpTR1owPzZprrHrL/h1vkWdysx7ed0dBnbs8uhtD4iPe46vWZqLc1ZyfV8QxefTD9mrS4VeH7rd4qOwMgkjphaoVc0/cOkt0u8p54961HLVt4euSZf0766hfYH+1EwvoShaiK/2aKTF/hmFavB2iASHRXJnOm9S4iDWyFW2D7XEwoo9o9jOAqtYbVefGglCjUymmuNCmj1bE3NSWXJB/5KC8xFNYs7b5jZ19diu5PQK2K1HCtJvLhW2wv7cBfBFrluvz52zeHB8izYIiSV+sr6mJgnPuwaoYUObJWkLlKpTo3oPgAU/62l0KMgdn1EoBrCSDVCz5IBjLmty25nFl1oDGZITQjNIkIMUjh4dojjr+JSRDumHxje39bu8nvxsA5pxDulnWQNorvaHeWf8t2ZAqYW/ojpAlmvBr7E+U9P6DHw40FDStcI8bJGfWv8yybjMocYtTTl6FaQdfqNm3Afp5wlUxNAkAG2neRGnuitHTQ4CBHquA9NG4c7tlyafUf9UMuce3ikQiUeecNnrW2tLkKEnkO6KXwgvOCAyQrFMHncPWXfQVY/+c/2ejelCOUW8BL2pBLBY="
+
+matrix:
+  include:
+    - os: linux
+      services: docker
+      sudo: required
+    - os: osx
+      osx_image: xcode8
+      sudo: required
+
+before_install:
+  - git submodule update --init --remote --merge --recursive
+
+script:
+  - ./Kitura-Build/script_travis.sh $TRAVIS_OS_NAME $TRAVIS_BRANCH $TRAVIS_BUILD_DIR cf-deployment-tracker-client-swift

--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,4 @@ export KITURA_CI_BUILD_SCRIPTS_DIR=Kitura-Build/build
 
 Kitura-Build/build/Makefile:
 	@echo --- Fetching Kitura-Build submodule
-	git submodule update --init --remote --recursive
-	cd Kitura-Build && git checkout master 
+	git submodule update --init --remote --merge --recursive


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

To consolidate logic between travis files and Makefiles to get the latest code for master branch
## Motivation and Context

Updates to makefile were to guarantee that we get the latest master code when we do a make locally.  The changes to to the .travis.yml file were to simplify the before_script section.
## How Has This Been Tested?

Ran the code through Travis CI which builds Kitura on linux and mac.  Also ran a build locally
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
