### PR TITLE
Update Kitura-net dependency to 1.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,6 @@ let package = Package(
     dependencies: [
       .Package(url: "https://github.com/IBM-Swift/Swift-cfenv.git", majorVersion: 1, minor: 9),
       .Package(url: "https://github.com/IBM-Swift/HeliumLogger.git", majorVersion: 1, minor: 3),
-      .Package(url: "https://github.com/IBM-Swift/Kitura-net.git", majorVersion: 1, minor: 3)
+      .Package(url: "https://github.com/IBM-Swift/Kitura-net.git", majorVersion: 1, minor: 4)
     ]
 )


### PR DESCRIPTION
Kitura-net 1.4 contains a fix for a memory leak when using URLComponents by changing to use URLURL. We are unable to build our Kitura app for deployment on Bluemix whilst latest Kitura requires Kitura-net v1.4 and this project requires v1.3 without having a fork of this project.